### PR TITLE
feat(ui): ask for confirmation before sending a vector layer to QChat

### DIFF
--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -1107,6 +1107,7 @@ Visit the website ?
                 duration=self.settings.notify_push_duration,
             )
             return
+
         layer = self.iface.activeLayer()
         if not layer:
             self.log(
@@ -1117,6 +1118,7 @@ Visit the website ?
                 duration=self.settings.notify_push_duration,
             )
             return
+
         if layer.type() != QgsMapLayer.LayerType.VectorLayer:
             self.log(
                 message=self.tr("Only vector layers can be sent on QChat"),
@@ -1125,6 +1127,21 @@ Visit the website ?
                 push=self.settings.notify_push_info,
                 duration=self.settings.notify_push_duration,
             )
+            return
+
+        if (
+            not QMessageBox.warning(
+                self,
+                self.tr("Sure ?"),
+                self.tr(
+                    """The "{layer_name}" layer will be sent to QChat.
+
+Are you sure ?"""
+                ).format(layer_name=layer.name()),
+                QMessageBox.Yes | QMessageBox.No,
+            )
+            == QMessageBox.Yes
+        ):
             return
 
         exporter = QgsJsonExporter(layer)

--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -1138,9 +1138,9 @@ Visit the website ?
 
 Are you sure ?"""
                 ).format(layer_name=layer.name()),
-                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             )
-            == QMessageBox.Yes
+            == QMessageBox.StandardButton.Yes
         ):
             return
 


### PR DESCRIPTION
Seems that some people accidentally send a layer in QChat, while they just want to open the layer properties (right-click).  
Thus a confirmation could prevent that.