### PR TITLE
feat: Add Discord-style slash commands to QChat

### DIFF
--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -117,7 +117,9 @@ class QChatWidget(QgsDockWidget):
             self.slash_command_handler.get_command_list()
         )
         self.command_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
-        self.command_completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self.command_completer.setCompletionMode(
+            QCompleter.CompletionMode.PopupCompletion
+        )
         self.lne_message.setCompleter(self.command_completer)
 
         # set channel to autoreconnect to when widget will open

--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -17,6 +17,7 @@ from qgis.PyQt.QtCore import QPoint, Qt
 from qgis.PyQt.QtGui import QCursor, QIcon
 from qgis.PyQt.QtWidgets import (
     QAction,
+    QCompleter,
     QFileDialog,
     QMenu,
     QMessageBox,
@@ -69,6 +70,7 @@ from qchat.logic.qchat_messages import (
     QChatUncompliantMessage,
 )
 from qchat.logic.qchat_websocket import QChatWebsocket
+from qchat.logic.slash_commands import SlashCommandHandler
 from qchat.tasks.dizzy import DizzyTask
 from qchat.toolbelt import PlgLogger, PlgOptionsManager
 from qchat.toolbelt.commons import open_url_in_browser, play_resource_sound
@@ -106,6 +108,17 @@ class QChatWidget(QgsDockWidget):
         self.log = PlgLogger().log
         self.plg_settings = PlgOptionsManager()
         uic.loadUi(Path(__file__).parent / f"{Path(__file__).stem}.ui", self)
+
+        # Initialize slash commands handler
+        self.slash_command_handler = SlashCommandHandler()
+
+        # Setup autocomplete for slash commands
+        self.command_completer = QCompleter(
+            self.slash_command_handler.get_command_list()
+        )
+        self.command_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.command_completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self.lne_message.setCompleter(self.command_completer)
 
         # set channel to autoreconnect to when widget will open
         self.auto_reconnect_channel = auto_reconnect_channel
@@ -862,6 +875,38 @@ Channels:
 
         if not message_text:
             return
+
+        # Check if message is a slash command
+        if self.slash_command_handler.is_command(message_text):
+            result = self.slash_command_handler.execute(message_text)
+
+            if not result.success:
+                # Show error
+                self.log(
+                    message=result.error or self.tr("Error executing command"),
+                    log_level=Qgis.MessageLevel.Warning,
+                    push=True,
+                    duration=3,
+                )
+                self.lne_message.setText("")
+                return
+
+            # Clear input
+            self.lne_message.setText("")
+
+            # If there's a local action, execute it
+            if result.local_action:
+                action_result = result.local_action()
+                if action_result and action_result[0] == "show_message":
+                    # Show message locally via QMessageBox
+                    QMessageBox.information(self, self.tr("QChat"), action_result[1])
+                return
+
+            # If there's a message text, send it to chat
+            if result.message_text:
+                message_text = result.message_text
+            else:
+                return
 
         # send message to websocket
         message = QChatTextMessage(

--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 from qgis.core import Qgis, QgsApplication, QgsJsonExporter, QgsMapLayer, QgsProject
 from qgis.gui import QgisInterface, QgsDockWidget
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QPoint, Qt
+from qgis.PyQt.QtCore import QPoint, Qt, QTimer
 from qgis.PyQt.QtGui import QCursor, QIcon
 from qgis.PyQt.QtWidgets import (
     QAction,
@@ -121,6 +121,8 @@ class QChatWidget(QgsDockWidget):
             QCompleter.CompletionMode.PopupCompletion
         )
         self.lne_message.setCompleter(self.command_completer)
+        # Connect to activated signal to handle completion selection
+        self.command_completer.activated.connect(self.on_command_activated)
 
         # set channel to autoreconnect to when widget will open
         self.auto_reconnect_channel = auto_reconnect_channel
@@ -844,6 +846,11 @@ Channels:
         Action called when the send button is clicked
         """
 
+        # If the completer popup is visible, ignore this call
+        # The activated signal will handle it instead
+        if self.command_completer.popup().isVisible():
+            return
+
         # retrieve nickname and message
         nickname = self.settings.nickname
         avatar = self.settings.avatar
@@ -921,6 +928,15 @@ Channels:
         )
         self.qchat_ws.send_message(message)
         self.lne_message.setText("")
+
+    def on_command_activated(self, completion: str) -> None:
+        """
+        Handle when user selects a completion from QCompleter.
+        This is called when the user presses Enter while the completion popup is active.
+        We defer the send action slightly to ensure QCompleter finishes its text update.
+        """
+        # Use QTimer.singleShot to defer the action, allowing QCompleter to finish
+        QTimer.singleShot(0, self.on_send_button_clicked)
 
     def on_send_image_button_clicked(self) -> None:
         """

--- a/qchat/logic/slash_commands.py
+++ b/qchat/logic/slash_commands.py
@@ -1,0 +1,243 @@
+"""Slash commands handler for QChat.
+
+Provides Discord-style slash commands for fun interactions and utilities.
+"""
+
+import random
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+@dataclass
+class SlashCommandResult:
+    """Result of a slash command execution."""
+
+    success: bool
+    message_text: Optional[str] = None  # Text to send to chat
+    local_action: Optional[Callable] = None  # Local action to execute
+    error: Optional[str] = None
+
+
+class SlashCommandHandler:
+    """Handler for slash commands in QChat."""
+
+    # Magic 8-ball responses (classic answers)
+    EIGHT_BALL_RESPONSES = [
+        "It is certain",
+        "It is decidedly so",
+        "Without a doubt",
+        "Yes definitely",
+        "You may rely on it",
+        "As I see it, yes",
+        "Most likely",
+        "Outlook good",
+        "Yes",
+        "Signs point to yes",
+        "Reply hazy, try again",
+        "Ask again later",
+        "Better not tell you now",
+        "Cannot predict now",
+        "Concentrate and ask again",
+        "Don't count on it",
+        "My reply is no",
+        "My sources say no",
+        "Outlook not so good",
+        "Very doubtful",
+    ]
+
+    # Command descriptions for help/autocomplete
+    COMMAND_DESCRIPTIONS = {
+        "list": "List all available commands",
+        "shrug": "Send ¯\\_(ツ)_/¯",
+        "tableflip": "Send (╯°□°)╯︵ ┻━┻",
+        "lenny": "Send ( ͡° ͜ʖ ͡°)",
+        "yolo": "Convert message to UPPERCASE + 🎲",
+        "flip": "Flip a coin (heads or tails)",
+        "roll": "Roll dice (e.g. /roll 2d20)",
+        "8ball": "Ask the magic 8-ball",
+    }
+
+    def __init__(self):
+        """Initialize the slash command handler."""
+        self.commands = {
+            "list": self.cmd_list,
+            "shrug": self.cmd_shrug,
+            "tableflip": self.cmd_tableflip,
+            "lenny": self.cmd_lenny,
+            "yolo": self.cmd_yolo,
+            "flip": self.cmd_flip,
+            "roll": self.cmd_roll,
+            "8ball": self.cmd_8ball,
+        }
+
+    def get_command_list(self) -> list[str]:
+        """Get list of available commands (for autocomplete).
+
+        :return: list of command names with leading /
+        """
+        return [f"/{cmd}" for cmd in sorted(self.commands.keys())]
+
+    def is_command(self, text: str) -> bool:
+        """Check if the text is a slash command.
+
+        :param text: text to check
+        :return: True if text starts with /
+        """
+        return text.strip().startswith("/")
+
+    def execute(self, text: str) -> SlashCommandResult:
+        """Execute a slash command.
+
+        :param text: command text (e.g., "/shrug" or "/roll")
+        :return: SlashCommandResult with the result
+        """
+        text = text.strip()
+        if not self.is_command(text):
+            return SlashCommandResult(success=False, error="Not a command")
+
+        # Parse command and arguments
+        parts = text[1:].split(maxsplit=1)  # Remove leading /
+        command = parts[0].lower()
+        args = parts[1] if len(parts) > 1 else ""
+
+        # Execute command
+        if command in self.commands:
+            return self.commands[command](args)
+        else:
+            return SlashCommandResult(
+                success=False,
+                error=f"Unknown command: /{command}",
+            )
+
+    def cmd_shrug(self, args: str) -> SlashCommandResult:
+        """Shrug command: ¯\\_(ツ)_/¯
+
+        :param args: optional message after shrug
+        :return: SlashCommandResult
+        """
+        message = "¯\\_(ツ)_/¯"
+        if args:
+            message = f"{message} {args}"
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_tableflip(self, args: str) -> SlashCommandResult:
+        """Table flip command: (╯°□°)╯︵ ┻━┻
+
+        :param args: optional message after tableflip
+        :return: SlashCommandResult
+        """
+        message = "(╯°□°)╯︵ ┻━┻"
+        if args:
+            message = f"{message} {args}"
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_lenny(self, args: str) -> SlashCommandResult:
+        """Lenny face command: ( ͡° ͜ʖ ͡°)
+
+        :param args: optional message after lenny
+        :return: SlashCommandResult
+        """
+        message = "( ͡° ͜ʖ ͡°)"
+        if args:
+            message = f"{message} {args}"
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_yolo(self, args: str) -> SlashCommandResult:
+        """YOLO command: converts message to CAPS + emoji
+
+        :param args: message to yolo-fy
+        :return: SlashCommandResult
+        """
+        if not args:
+            message = "YOLO! 🎲"
+        else:
+            message = f"{args.upper()} 🎲"
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_flip(self, args: str) -> SlashCommandResult:
+        """Coin flip command: heads or tails
+
+        :param args: unused
+        :return: SlashCommandResult
+        """
+        result = random.choice(["Heads", "Tails"])
+        emoji = "🪙"
+        message = f"{emoji} {result}!"
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_roll(self, args: str) -> SlashCommandResult:
+        """Dice roll command: 1-6
+
+        :param args: optional dice specification (e.g., "2d20" for 2 dice of 20 sides)
+        :return: SlashCommandResult
+        """
+        # Parse args for custom dice (e.g., "2d20")
+        num_dice = 1
+        num_sides = 6
+
+        if args:
+            try:
+                if "d" in args.lower():
+                    parts = args.lower().split("d")
+                    num_dice = int(parts[0]) if parts[0] else 1
+                    num_sides = int(parts[1]) if parts[1] else 6
+                else:
+                    num_sides = int(args)
+            except (ValueError, IndexError):
+                return SlashCommandResult(
+                    success=False,
+                    error="Invalid format. Use /roll [faces] or /roll [number]d[faces]",
+                )
+
+        # Validate
+        if num_dice < 1 or num_dice > 100:
+            return SlashCommandResult(
+                success=False, error="Invalid number of dice (1-100)"
+            )
+        if num_sides < 2 or num_sides > 1000:
+            return SlashCommandResult(
+                success=False, error="Invalid number of sides (2-1000)"
+            )
+
+        # Roll
+        rolls = [random.randint(1, num_sides) for _ in range(num_dice)]
+        total = sum(rolls)
+
+        if num_dice == 1:
+            message = f"🎲 {rolls[0]}"
+        else:
+            rolls_str = ", ".join(str(r) for r in rolls)
+            message = f"🎲 {rolls_str} (total: {total})"
+
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_8ball(self, args: str) -> SlashCommandResult:
+        """Magic 8-ball command: random answer
+
+        :param args: the question (optional)
+        :return: SlashCommandResult
+        """
+        answer = random.choice(self.EIGHT_BALL_RESPONSES)
+        emoji = "🎱"
+        message = f"{emoji} {answer}"
+        return SlashCommandResult(success=True, message_text=message)
+
+    def cmd_list(self, args: str) -> SlashCommandResult:
+        """List all available commands.
+
+        :param args: unused
+        :return: SlashCommandResult (local action, not sent to chat)
+        """
+        # Build command list with descriptions
+        lines = ["📋 Available commands:"]
+        for cmd in sorted(self.commands.keys()):
+            desc = self.COMMAND_DESCRIPTIONS.get(cmd, "")
+            lines.append(f"  /{cmd} - {desc}")
+
+        message = "\n".join(lines)
+
+        # Return as local action (display locally, don't send to chat)
+        return SlashCommandResult(
+            success=True,
+            local_action=lambda: ("show_message", message),
+        )

--- a/qchat/logic/slash_commands.py
+++ b/qchat/logic/slash_commands.py
@@ -192,7 +192,7 @@ class SlashCommandHandler:
         # Validate
         if num_dice < 1 or num_dice > 100:
             return SlashCommandResult(
-                success=False, error="Invalid number of dice (1-100)"
+                success=False, error="Invalid number of dice [1-100]"
             )
         if num_sides < 2 or num_sides > 1000:
             return SlashCommandResult(


### PR DESCRIPTION
Implements a comprehensive slash command system inspired by Discord, adding fun interactions and useful utilities to the chat.

Features:
- Fun text commands: /shrug, /tableflip, /lenny, /yolo
- Random commands: /flip (coin flip), /roll (dice), /8ball (magic 8-ball)
- /list command: displays all available commands with descriptions
- Autocomplete: automatic command suggestions when typing

New files:
- qchat/logic/slash_commands.py: Command handler system
- docs/usage/slash_commands.md: User documentation

Modified:
- qchat/gui/dck_qchat.py: Command interception

Technical details:
- Extensible architecture for easy command additions
- Comprehensive error handling

Examples:
- /shrug → sends "¯\_(ツ)_/¯"
- /roll 2d20 → rolls 2 dice with 20 faces


This is not sponsored by :

<img width="168" height="300" alt="image" src="https://github.com/user-attachments/assets/73212674-26c8-4dd1-9f27-eacc44f45950" />
