### PR TITLE
fix(ui): disable sending position on canvas right-clic

### DIFF
--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -278,12 +278,13 @@ class QChatWidget(QgsDockWidget):
             self.generate_qaction_send_geojson_layer
         )
 
+        # Note: disabled for now since it messes with vectorizing lines.
         # context menu on right-click on the canvas for sending position in QChat
-        map_canvas = self.iface.mapCanvas()
-        map_canvas.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        map_canvas.customContextMenuRequested.connect(
-            self.custom_qchat_position_context_menu
-        )
+        # map_canvas = self.iface.mapCanvas()
+        # map_canvas.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        # map_canvas.customContextMenuRequested.connect(
+        #     self.custom_qchat_position_context_menu
+        # )
 
         # auto reconnect to channel if needed
         if self.auto_reconnect_channel:


### PR DESCRIPTION
This "send position" on canvas right-click feature is not ready, and messes up the vectorization of lines, thus we should disable it for now. Will maybe come with a follow-up and a more fancy way to send a position coordinate in QChat.

Closes #36 