### PR TITLE
feature: display a confirmation message based on a new setting

### DIFF
--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -974,6 +974,22 @@ Channels:
         Action called when the Send QGIS screenshot button is clicked
         """
 
+        if (
+            self.settings.confirm_before_send
+            and QMessageBox.warning(
+                self,
+                self.tr("Sure ?"),
+                self.tr(
+                    """Screenshot of current QGIS map will be sent to QChat.
+
+Are you sure ?"""
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            != QMessageBox.StandardButton.Yes
+        ):
+            return
+
         sc_fp = Path(tempfile.gettempdir()) / "qgis_screenshot.png"
         self.iface.mapCanvas().saveAsImage(str(sc_fp))
         with open(sc_fp, "rb") as file:
@@ -992,6 +1008,22 @@ Channels:
         """
         Action called when the Send extent button is clicked
         """
+        if (
+            self.settings.confirm_before_send
+            and QMessageBox.warning(
+                self,
+                self.tr("Sure ?"),
+                self.tr(
+                    """The current map extent will be sent to QChat.
+
+Are you sure ?"""
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            != QMessageBox.StandardButton.Yes
+        ):
+            return
+
         crs = QgsProject.instance().crs()
         rect = self.iface.mapCanvas().extent()
         message = QChatBboxMessage(
@@ -1013,6 +1045,22 @@ Channels:
         """
         Action called when the Send CRS button is clicked
         """
+        if (
+            self.settings.confirm_before_send
+            and QMessageBox.warning(
+                self,
+                self.tr("Sure ?"),
+                self.tr(
+                    """The current CRS will be sent to QChat.
+
+Are you sure ?"""
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            != QMessageBox.StandardButton.Yes
+        ):
+            return
+
         crs = QgsProject.instance().crs()
         message = QChatCrsMessage(
             type=QCHAT_MESSAGE_TYPE_CRS,
@@ -1208,7 +1256,8 @@ Visit the website ?
             return
 
         if (
-            not QMessageBox.warning(
+            self.settings.confirm_before_send
+            and QMessageBox.warning(
                 self,
                 self.tr("Sure ?"),
                 self.tr(
@@ -1218,7 +1267,7 @@ Are you sure ?"""
                 ).format(layer_name=layer.name()),
                 QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             )
-            == QMessageBox.StandardButton.Yes
+            != QMessageBox.StandardButton.Yes
         ):
             return
 

--- a/qchat/gui/dlg_settings.py
+++ b/qchat/gui/dlg_settings.py
@@ -129,6 +129,7 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         settings.display_admin_messages = self.ckb_display_admin_messages.isChecked()
         settings.show_avatars = self.ckb_show_avatars.isChecked()
         settings.incognito_mode = self.ckb_incognito_mode.isChecked()
+        settings.confirm_before_send = self.ckb_confirm_before_send.isChecked()
         settings.play_sounds = self.ckb_play_sounds.isChecked()
         settings.sound_volume = self.hsl_sound_volume.value()
         settings.ring_tone = self.cbb_ring_tone.currentText()
@@ -182,6 +183,7 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         self.ckb_display_admin_messages.setChecked(settings.display_admin_messages)
         self.ckb_show_avatars.setChecked(settings.show_avatars)
         self.ckb_incognito_mode.setChecked(settings.incognito_mode)
+        self.ckb_confirm_before_send.setChecked(settings.confirm_before_send)
         self.ckb_play_sounds.setChecked(settings.play_sounds)
         self.hsl_sound_volume.setValue(settings.sound_volume)
         beep_index = self.cbb_ring_tone.findText(

--- a/qchat/gui/dlg_settings.ui
+++ b/qchat/gui/dlg_settings.ui
@@ -221,6 +221,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="ckb_confirm_before_send">
+          <property name="toolTip">
+           <string extracomment="When sending a specific message, if QChat should display a confirmation dialog"/>
+          </property>
+          <property name="text">
+           <string>Confirm before send</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="ckb_display_admin_messages">
           <property name="toolTip">
            <string extracomment="Display connections and disconnections messages"/>

--- a/qchat/toolbelt/preferences.py
+++ b/qchat/toolbelt/preferences.py
@@ -77,6 +77,7 @@ class PlgSettingsStructure:
     display_admin_messages: bool = False
     show_avatars: bool = True
     incognito_mode: bool = False
+    confirm_before_send: bool = True
     play_sounds: bool = True
     sound_volume: int = 33
     ring_tone: str = "beep_1"


### PR DESCRIPTION
When sending a "geo" message - e.g. vector layer, bbox, crs, etc., a new setting will make a confirmation dialog appear, or not.