### PR TITLE
tooling(pre-commit): add `bandit` pre-commit hook

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,0 +1,4 @@
+exclude_dirs:
+  - tests
+  - .venv
+  - docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,13 @@ repos:
             "--select=E9,F63,F7,F82,QGS101,QGS102,QGS103,QGS104,QGS106",
           ]
 
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        files: ^qchat/.*\.py$
+        args: ["-c", ".bandit.yaml"]
+
 ci:
     autoupdate_schedule: quarterly
     skip: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
     hooks:
       - id: bandit
         files: ^qchat/.*\.py$
-        args: ["-c", ".bandit.yaml"]
+        args: ["-c", ".bandit.yaml", "-ll"]
 
 ci:
     autoupdate_schedule: quarterly


### PR DESCRIPTION
Adding `bandit` pre-commit hook, since [it's now part of the `plugins.qgis.org` checks](https://plugins.qgis.org/docs/security-scanning).

Disclosure : ran a few GenAI prompts to setup the bandit config.