### PR TITLE
feat(qchat): add thread logic

### DIFF
--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -5,7 +5,7 @@ import tempfile
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -22,7 +22,15 @@ from qgis.core import (
 )
 from qgis.gui import QgisInterface, QgsDockWidget, QgsMapMouseEvent
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QAbstractListModel, QPoint, QStringListModel, Qt, QTimer
+from qgis.PyQt.QtCore import (
+    QAbstractListModel,
+    QEvent,
+    QObject,
+    QPoint,
+    QStringListModel,
+    Qt,
+    QTimer,
+)
 from qgis.PyQt.QtGui import QCursor, QIcon
 from qgis.PyQt.QtWidgets import (
     QAction,
@@ -30,6 +38,7 @@ from qgis.PyQt.QtWidgets import (
     QFileDialog,
     QMenu,
     QMessageBox,
+    QTreeWidget,
     QTreeWidgetItem,
     QWidget,
 )
@@ -73,6 +82,7 @@ from qchat.gui.qchat_tree_widget_items import (
     QChatPositionTreeWidgetItem,
     QChatScriptTreeWidgetItem,
     QChatTextTreeWidgetItem,
+    QChatTreeWidgetItem,
 )
 from qchat.logic.qchat_api_client import QChatApiClient
 from qchat.logic.qchat_messages import (
@@ -207,6 +217,11 @@ class QChatWidget(QgsDockWidget):
         self.btn_connect.pressed.connect(self.on_connect_button_clicked)
         self.btn_connect.setIcon(QIcon(QgsApplication.iconPath("mIconConnect.svg")))
 
+        # message id -> tree widget item, used for threading
+        self.message_items: dict[str, QTreeWidgetItem] = {}
+        self.reply_to_id: Optional[str] = None
+        self.reply_to_author: Optional[str] = None
+
         # tree widget initialization
         self.twg_chat.setHeaderLabels(
             [
@@ -268,6 +283,8 @@ class QChatWidget(QgsDockWidget):
         )
         self.qchat_ws.model_message_received.connect(self.on_model_message_received)
         self.qchat_ws.script_message_received.connect(self.on_script_message_received)
+
+        self.lne_message.installEventFilter(self)
 
         # send message signal listener
         self.lne_message.returnPressed.connect(self.on_send_button_clicked)
@@ -389,6 +406,47 @@ class QChatWidget(QgsDockWidget):
         # auto reconnect to channel if needed
         if self.auto_reconnect_channel:
             self.cbb_channel.setCurrentText(self.auto_reconnect_channel)
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if (
+            obj is self.lne_message
+            and event.type() == QEvent.Type.KeyPress
+            and event.key() == Qt.Key.Key_Escape
+            and self.reply_to_id
+        ):
+            self.cancel_reply()
+            return True
+        return super().eventFilter(obj, event)
+
+    def _get_message_parent_item(
+        self, in_reply_to_id: Optional[str]
+    ) -> Union[QTreeWidget, QChatTreeWidgetItem]:
+        if in_reply_to_id and in_reply_to_id in self.message_items:
+            target = self.message_items[in_reply_to_id]
+            # If target is already a subitem, attach the reply at the same level
+            # (i.e. return target's parent) to keep thread depth at 1.
+            qt_parent = target.parent()
+            if isinstance(qt_parent, QChatTreeWidgetItem):
+                return cast(QChatTreeWidgetItem, qt_parent)
+            return target
+        return self.twg_chat
+
+    def cancel_reply(self) -> None:
+
+        self.reply_to_id = None
+        self.reply_to_author = None
+        self.lne_message.setPlaceholderText("")
+
+    def on_reply_to_message(self, item: QChatTreeWidgetItem) -> None:
+        """
+        Action called when the "Reply to message" action is triggered
+        """
+        self.reply_to_id = item.message_id
+        self.reply_to_author = item.author
+        self.lne_message.setPlaceholderText(
+            self.tr("< {author}... (Esc to cancel)").format(author=item.author)
+        )
+        self.lne_message.setFocus()
 
     def on_rules_button_clicked(self) -> None:
         """
@@ -565,6 +623,8 @@ Channels:
 
         self.connected = True
         self.twg_chat.clear()
+        self.message_items.clear()
+        self.cancel_reply()
         if self.settings.display_admin_messages:
             self.add_admin_message(
                 self.tr("Connected to channel '{channel}'").format(channel=channel)
@@ -646,7 +706,8 @@ Channels:
         if message.text in CHEATCODES:
             return
 
-        item = QChatTextTreeWidgetItem(self.twg_chat, message)
+        parent = self._get_message_parent_item(message.in_reply_to_id)
+        item = QChatTextTreeWidgetItem(parent, message)
 
         # check if message mentions current user
         words = message.text.split(" ")
@@ -668,14 +729,15 @@ Channels:
                         self.settings.ring_tone, self.settings.sound_volume
                     )
 
-        self.add_tree_widget_item(item)
+        self.add_tree_widget_item(item, message.id)
 
     def on_image_message_received(self, message: QChatImageMessage) -> None:
         """
         Launched when an image message is received from the websocket
         """
-        item = QChatImageTreeWidgetItem(self.twg_chat, message)
-        self.add_tree_widget_item(item)
+        parent = self._get_message_parent_item(message.in_reply_to_id)
+        item = QChatImageTreeWidgetItem(parent, message)
+        self.add_tree_widget_item(item, message.id)
 
     def on_nb_users_message_received(self, message: QChatNbUsersMessage) -> None:
         """
@@ -764,31 +826,33 @@ Channels:
         """
         Launched when a geojson message is received from the websocket
         """
-        item = QChatGeojsonTreeWidgetItem(self.twg_chat, message)
-        self.add_tree_widget_item(item)
+        parent = self._get_message_parent_item(message.in_reply_to_id)
+        item = QChatGeojsonTreeWidgetItem(parent, message)
+        self.add_tree_widget_item(item, message.id)
 
     def on_crs_message_received(self, message: QChatCrsMessage) -> None:
         """
         Launched when a CRS message is received from the websocket
         """
-        item = QChatCrsTreeWidgetItem(self.twg_chat, message)
-        self.add_tree_widget_item(item)
+        parent = self._get_message_parent_item(message.in_reply_to_id)
+        item = QChatCrsTreeWidgetItem(parent, message)
+        self.add_tree_widget_item(item, message.id)
 
     def on_bbox_message_received(self, message: QChatBboxMessage) -> None:
         """
         Launched when a BBOX message is received from the websocket
         """
-        item = QChatBboxTreeWidgetItem(self.twg_chat, message, self.iface.mapCanvas())
-        self.add_tree_widget_item(item)
+        parent = self._get_message_parent_item(message.in_reply_to_id)
+        item = QChatBboxTreeWidgetItem(parent, message, self.iface.mapCanvas())
+        self.add_tree_widget_item(item, message.id)
 
     def on_position_message_received(self, message: QChatPositionMessage) -> None:
         """
         Launched when a POSITION message is received from the websocket
         """
-        item = QChatPositionTreeWidgetItem(
-            self.twg_chat, message, self.iface.mapCanvas()
-        )
-        self.add_tree_widget_item(item)
+        parent = self._get_message_parent_item(message.in_reply_to_id)
+        item = QChatPositionTreeWidgetItem(parent, message, self.iface.mapCanvas())
+        self.add_tree_widget_item(item, message.id)
 
     def on_model_message_received(self, message: QChatModelMessage) -> None:
         """
@@ -818,10 +882,21 @@ Channels:
         """
         author = item.author
         # do nothing if double click on admin message
-        if author == ADMIN_MESSAGES_NICKNAME or author == self.settings.nickname:
+        if author == ADMIN_MESSAGES_NICKNAME:
             return
+
+        self.reply_to_id = item.message_id
+        self.reply_to_author = author
+        self.lne_message.setPlaceholderText(
+            self.tr("< {author}... (Esc to cancel)").format(author=author)
+        )
+
         text = self.lne_message.text()
-        self.lne_message.setText(f"{text}@{author} ")
+        if author != self.settings.nickname:
+            self.lne_message.setText(f"{text}@{author} ")
+        else:
+            self.lne_message.setText(text)
+
         self.lne_message.setFocus()
 
     def on_like_message(self, liked_author: str, msg: str) -> None:
@@ -846,6 +921,15 @@ Channels:
         item = self.twg_chat.itemAt(point)
 
         menu = QMenu(self.tr("QChat Menu"), self)
+
+        # reply to message action if possible
+        if item.can_be_replied_to:
+            reply_action = QAction(
+                QgsApplication.getThemeIcon("mMessageLog.svg"),
+                self.tr("Reply in thread"),
+            )
+            reply_action.triggered.connect(partial(self.on_reply_to_message, item))
+            menu.addAction(reply_action)
 
         # like message action if possible
         if item.can_be_liked:
@@ -926,6 +1010,8 @@ Channels:
         Action called when the clear chat button is clicked
         """
         self.twg_chat.clear()
+        self.message_items.clear()
+        self.cancel_reply()
 
     def on_send_button_clicked(self) -> None:
         """
@@ -1014,9 +1100,11 @@ Channels:
             author=nickname,
             avatar=avatar,
             text=message_text.strip(),
+            in_reply_to_id=self.reply_to_id,
         )
         self.qchat_ws.send_message(message)
         self.lne_message.setText("")
+        self.cancel_reply()
 
     def on_command_activated(self, completion: str) -> None:
         """
@@ -1157,8 +1245,16 @@ Are you sure ?"""),
         item = QChatAdminTreeWidgetItem(self.twg_chat, text, timestamp)
         self.add_tree_widget_item(item)
 
-    def add_tree_widget_item(self, item: QTreeWidgetItem) -> None:
-        self.twg_chat.addTopLevelItem(item)
+    def add_tree_widget_item(
+        self, item: QTreeWidgetItem, message_id: Optional[str] = None
+    ) -> None:
+        if message_id:
+            self.message_items[message_id] = item
+        parent_item = item.parent()
+        if parent_item:
+            parent_item.setExpanded(True)
+        else:
+            self.twg_chat.addTopLevelItem(item)
         if self.ckb_autoscroll.isChecked():
             self.twg_chat.scrollToItem(item)
 
@@ -1240,15 +1336,13 @@ Are you sure ?"""),
         msg_box = QMessageBox()
         msg_box.setWindowTitle("QGIS")
         msg_box.setIcon(QMessageBox.Icon.Information)
-        msg_box.setText(
-            self.tr("""No... it was a joke!
+        msg_box.setText(self.tr("""No... it was a joke!
 
 QGIS is Free and Open Source software, forever.
 Free to use, not to make.
 
 Visit the website ?
-""")
-        )
+"""))
         msg_box.setStandardButtons(QMessageBox.StandardButton.Yes)
         return_value = msg_box.exec()
         if return_value == QMessageBox.StandardButton.Yes:

--- a/qchat/gui/dck_qchat.py
+++ b/qchat/gui/dck_qchat.py
@@ -1336,13 +1336,15 @@ Are you sure ?"""),
         msg_box = QMessageBox()
         msg_box.setWindowTitle("QGIS")
         msg_box.setIcon(QMessageBox.Icon.Information)
-        msg_box.setText(self.tr("""No... it was a joke!
+        msg_box.setText(
+            self.tr("""No... it was a joke!
 
 QGIS is Free and Open Source software, forever.
 Free to use, not to make.
 
 Visit the website ?
-"""))
+""")
+        )
         msg_box.setStandardButtons(QMessageBox.StandardButton.Yes)
         return_value = msg_box.exec()
         if return_value == QMessageBox.StandardButton.Yes:

--- a/qchat/gui/qchat_tree_widget_items.py
+++ b/qchat/gui/qchat_tree_widget_items.py
@@ -3,7 +3,7 @@ import json
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from processing.modeler.ModelerUtils import ModelerUtils
 from processing.script import ScriptUtils
@@ -119,16 +119,18 @@ class QChatTreeWidgetItem(QTreeWidgetItem):
 
     def __init__(
         self,
-        parent: QTreeWidget,
+        parent: Union[QTreeWidget, "QChatTreeWidgetItem"],
         datetime: QDateTime,
         author: str,
         avatar: Optional[str],
-    ):
+        message_id: Optional[str] = None,
+    ) -> None:
         super().__init__(parent)
         self.plg_settings = PlgOptionsManager()
         self.datetime = datetime
         self.author = author
         self.avatar = avatar
+        self.message_id = message_id
 
     @property
     def settings(self) -> PlgSettingsStructure:
@@ -154,6 +156,10 @@ class QChatTreeWidgetItem(QTreeWidgetItem):
         :param column: column that has been clicked
         """
         pass
+
+    @property
+    def can_be_replied_to(self) -> bool:
+        return self.message_id is not None
 
     @property
     def can_be_liked(self) -> bool:
@@ -219,12 +225,13 @@ class QChatAdminTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatTextTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(self, parent: QTreeWidget, message: QChatTextMessage):
+    def __init__(self, parent, message: QChatTextMessage):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.init_time_and_author()
@@ -253,12 +260,13 @@ class QChatTextTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatImageTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(self, parent: QTreeWidget, message: QChatImageMessage):
+    def __init__(self, parent, message: QChatImageMessage):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.init_time_and_author()
@@ -310,12 +318,13 @@ class QChatImageTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatGeojsonTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(self, parent: QTreeWidget, message: QChatGeojsonMessage):
+    def __init__(self, parent, message: QChatGeojsonMessage):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.init_time_and_author()
@@ -379,12 +388,13 @@ class QChatGeojsonTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatCrsTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(self, parent: QTreeWidget, message: QChatCrsMessage):
+    def __init__(self, parent, message: QChatCrsMessage):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.init_time_and_author()
@@ -424,14 +434,13 @@ class QChatCrsTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatBboxTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(
-        self, parent: QTreeWidget, message: QChatBboxMessage, canvas: QgsMapCanvas
-    ):
+    def __init__(self, parent, message: QChatBboxMessage, canvas: QgsMapCanvas):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp).toLocalTime(),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.canvas = canvas
@@ -486,14 +495,13 @@ class QChatBboxTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatPositionTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(
-        self, parent: QTreeWidget, message: QChatPositionMessage, canvas: QgsMapCanvas
-    ):
+    def __init__(self, parent, message: QChatPositionMessage, canvas: QgsMapCanvas):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp).toLocalTime(),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.canvas = canvas

--- a/qchat/gui/qchat_tree_widget_items.py
+++ b/qchat/gui/qchat_tree_widget_items.py
@@ -43,6 +43,7 @@ from qchat.logic.qchat_messages import (
     QChatImageMessage,
     QChatModelMessage,
     QChatPositionMessage,
+    QChatScriptMessage,
     QChatTextMessage,
 )
 from qchat.toolbelt import PlgOptionsManager
@@ -546,12 +547,13 @@ class QChatPositionTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatModelTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(self, parent: QTreeWidget, message: QChatModelMessage):
+    def __init__(self, parent, message: QChatModelMessage):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp).toLocalTime(),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.init_time_and_author()
@@ -622,12 +624,13 @@ class QChatModelTreeWidgetItem(QChatTreeWidgetItem):
 
 
 class QChatScriptTreeWidgetItem(QChatTreeWidgetItem):
-    def __init__(self, parent: QTreeWidget, message):
+    def __init__(self, parent, message: QChatScriptMessage):
         super().__init__(
             parent,
             QDateTime.fromSecsSinceEpoch(message.timestamp).toLocalTime(),
             message.author,
             message.avatar,
+            message_id=message.id,
         )
         self.message = message
         self.init_time_and_author()

--- a/qchat/logic/qchat_messages.py
+++ b/qchat/logic/qchat_messages.py
@@ -104,6 +104,7 @@ class QChatModelMessage(QChatMessage):
     model_name: str
     model_group: Optional[str]
     raw_xml: str
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)
@@ -112,3 +113,4 @@ class QChatScriptMessage(QChatMessage):
     avatar: Optional[str]
     name: str
     raw_pycode: str
+    in_reply_to_id: Optional[str] = None

--- a/qchat/logic/qchat_messages.py
+++ b/qchat/logic/qchat_messages.py
@@ -19,6 +19,7 @@ class QChatTextMessage(QChatMessage):
     author: str
     avatar: Optional[str]
     text: str
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)
@@ -26,6 +27,7 @@ class QChatImageMessage(QChatMessage):
     author: str
     avatar: Optional[str]
     image_data: str
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)
@@ -59,6 +61,7 @@ class QChatGeojsonMessage(QChatMessage):
     crs_authid: str
     geojson: dict
     style: Optional[str]
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)
@@ -67,6 +70,7 @@ class QChatCrsMessage(QChatMessage):
     avatar: Optional[str]
     crs_wkt: str
     crs_authid: str
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)
@@ -79,6 +83,7 @@ class QChatBboxMessage(QChatMessage):
     xmax: float
     ymin: float
     ymax: float
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)
@@ -89,6 +94,7 @@ class QChatPositionMessage(QChatMessage):
     crs_authid: str
     x: float
     y: float
+    in_reply_to_id: Optional[str] = None
 
 
 @dataclass(init=True, frozen=True)


### PR DESCRIPTION
Adding messages thread logic in QChat,

Works with the new `in_reply_to_id` message key,  
See gischat backend implementation : https://github.com/geotribu/gischat/pull/137

https://github.com/user-attachments/assets/9a21ae96-2598-42d0-8530-f43519ea5ee6

### Changes

- add a `in_reply_to_id` key in the message models, in order to be compliant with the backend,
- a parent of a `QChatTreeWidgetItem` can be either a `QTreeWidget` as it was before (no "parent" so 1st level message), either a `QChatTreeWidgetItem` to get the thread effect,
- add a `message_id` to the `QChatTreeWidgetItem` objects, potentially stored in a `message_items` dict with logic to get a potential message parent and set it so that the message is a subthread - in reply to its parent,
- add UI logic to reply in a thread when double-clicking on a message, or on a new context menu action (right-click on a message)
- only one level of message threading, at the beginning it was possible to have multiple levels e.g. subthreads of thread answers. Better keep only one level of thread depth,

### TODO

- do more tests especially regarding the edge cases, i.e. when a message gets deleted, when a channel changes, etc.
- at the moment, only text messages can be added as a thread answer -> add the ability to also answer with image / crs / extent etc. in a thread,

Note : I used some LLMs to help me get there.