### PR TITLE
fix: fix `QtMultimedia` import on Qt6

### DIFF
--- a/qchat/toolbelt/commons.py
+++ b/qchat/toolbelt/commons.py
@@ -4,14 +4,19 @@
 from qgis.core import Qgis
 from qgis.PyQt.QtCore import QT_VERSION_STR, QUrl
 from qgis.PyQt.QtGui import QDesktopServices
-from qgis.PyQt.QtMultimedia import QMediaContent, QMediaPlayer
 
 from qchat.__about__ import DIR_PLUGIN_ROOT
 from qchat.toolbelt.log_handler import PlgLogger
 
-if int(QT_VERSION_STR.split(".")[0]) == 6:
+# conditional import depending on Qt version
+if int(QT_VERSION_STR.split(".")[0]) == 5:
+    from PyQt5.QtMultimedia import QMediaContent, QMediaPlayer  # noqa QGS103
+elif int(QT_VERSION_STR.split(".")[0]) == 6:
     # see: https://doc.qt.io/qt-6/qtmultimedia-changes-qt6.html
     QMediaContent = QUrl
+    from PyQt6.QtMultimedia import QMediaPlayer  # noqa QGS103
+else:
+    QMediaPlayer = None
 
 
 def open_url_in_browser(url: str) -> bool:

--- a/qchat/toolbelt/commons.py
+++ b/qchat/toolbelt/commons.py
@@ -15,6 +15,7 @@ elif int(QT_VERSION_STR.split(".")[0]) == 6:
     # see: https://doc.qt.io/qt-6/qtmultimedia-changes-qt6.html
     QMediaContent = QUrl
     from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer  # noqa QGS103
+
     qt6_player = QMediaPlayer()
     qt6_audio_output = QAudioOutput()
 else:

--- a/qchat/toolbelt/commons.py
+++ b/qchat/toolbelt/commons.py
@@ -14,7 +14,7 @@ if int(QT_VERSION_STR.split(".")[0]) == 5:
 elif int(QT_VERSION_STR.split(".")[0]) == 6:
     # see: https://doc.qt.io/qt-6/qtmultimedia-changes-qt6.html
     QMediaContent = QUrl
-    from PyQt6.QtMultimedia import QMediaPlayer  # noqa QGS103
+    from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer  # noqa QGS103
 else:
     QMediaPlayer = None
 
@@ -55,9 +55,20 @@ def play_sound(file: str, volume: int) -> None:
         )
         return
 
-    # play sound
+    url = QUrl.fromLocalFile(file)
     player = QMediaPlayer()
-    player.setMedia(QMediaContent(url))
-    player.setVolume(volume)
-    player.audioAvailableChanged.connect(lambda: player.play())
-    player.play()
+
+    # play sound
+    if int(QT_VERSION_STR.split(".")[0]) == 5:
+        player.setMedia(QMediaContent(url))
+        player.setVolume(volume)
+        player.audioAvailableChanged.connect(lambda: player.play())
+        player.play()
+    elif int(QT_VERSION_STR.split(".")[0]) == 6:
+        # Qt6 : setSource() remplace setMedia()
+        audio_output = QAudioOutput()
+        # volume goes through audio output in Qt6
+        audio_output.setVolume(volume / 100.0)  # expects a float between 0 and 1
+        player.setAudioOutput(audio_output)
+        player.setSource(url)
+        player.play()

--- a/qchat/toolbelt/commons.py
+++ b/qchat/toolbelt/commons.py
@@ -40,14 +40,13 @@ def play_resource_sound(resource: str, volume: int) -> None:
     file_path = DIR_PLUGIN_ROOT / f"resources/sounds/{resource}.mp3"
     if not file_path.exists():
         raise FileNotFoundError(
-            f"File '{resource}.wav' not found in resources/sounds folder"
+            f"File '{resource}.mp3' not found in resources/sounds folder"
         )
     play_sound(f"{file_path.resolve()}", volume)
 
 
 def play_sound(file: str, volume: int) -> None:
     """Play a sound using QtMultimedia QMediaPlayer."""
-    url = QUrl.fromLocalFile(file)
     if QMediaPlayer is None:
         PlgLogger.log(
             message="QMediaPlayer is not available. Sound cannot be played.",
@@ -65,10 +64,9 @@ def play_sound(file: str, volume: int) -> None:
         player.audioAvailableChanged.connect(lambda: player.play())
         player.play()
     elif int(QT_VERSION_STR.split(".")[0]) == 6:
-        # Qt6 : setSource() remplace setMedia()
         audio_output = QAudioOutput()
-        # volume goes through audio output in Qt6
-        audio_output.setVolume(volume / 100.0)  # expects a float between 0 and 1
+        # expects a float between 0 and 1
+        audio_output.setVolume(volume / 100.0)
         player.setAudioOutput(audio_output)
         player.setSource(url)
         player.play()

--- a/qchat/toolbelt/commons.py
+++ b/qchat/toolbelt/commons.py
@@ -15,6 +15,8 @@ elif int(QT_VERSION_STR.split(".")[0]) == 6:
     # see: https://doc.qt.io/qt-6/qtmultimedia-changes-qt6.html
     QMediaContent = QUrl
     from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer  # noqa QGS103
+    qt6_player = QMediaPlayer()
+    qt6_audio_output = QAudioOutput()
 else:
     QMediaPlayer = None
 
@@ -55,18 +57,16 @@ def play_sound(file: str, volume: int) -> None:
         return
 
     url = QUrl.fromLocalFile(file)
-    player = QMediaPlayer()
-
     # play sound
     if int(QT_VERSION_STR.split(".")[0]) == 5:
-        player.setMedia(QMediaContent(url))
-        player.setVolume(volume)
-        player.audioAvailableChanged.connect(lambda: player.play())
-        player.play()
+        qt5_player = QMediaPlayer()
+        qt5_player.setMedia(QMediaContent(url))
+        qt5_player.setVolume(volume)
+        qt5_player.audioAvailableChanged.connect(lambda: qt5_player.play())
+        qt5_player.play()
     elif int(QT_VERSION_STR.split(".")[0]) == 6:
-        audio_output = QAudioOutput()
         # expects a float between 0 and 1
-        audio_output.setVolume(volume / 100.0)
-        player.setAudioOutput(audio_output)
-        player.setSource(url)
-        player.play()
+        qt6_audio_output.setVolume(volume / 100.0)
+        qt6_player.setAudioOutput(qt6_audio_output)
+        qt6_player.setSource(url)
+        qt6_player.play()


### PR DESCRIPTION
Revert de ce commit un peu trop confiant : https://github.com/geotribu/qchat/pull/66/changes/31d3f688d05d0ddb5bb397d5596ae65a423bc1d1

<details>
<summary>Avec en prime...</summary>

![Harold a des erreurs lors de sa migration Qt6](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/2025/retrospective_qalendrier_2025/5_harold_run_pyqt5_to_pyqt6_script.webp)

</details>